### PR TITLE
feat(casl): Introduce storage interface

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,23 +1,32 @@
+// Create a Store
+export const createStore = (hash, storage) =>
+  new Store(hash, storage)
+
 // Create a Store that holds values in localStorage
-// The the returned store will have the value addressed by the provided key
-export const localStore = (hash, localStorage, key) =>
-  new Store(jsonSerializer(hash), jsonDeserializer, localStorage, key)
+export const localStore = (hash, localStorage) =>
+  createStore(hash, new LocalStorage(localStorage))
 
-export const jsonDeserializer = json =>
-  json == null ? undefined : JSON.parse(json)
+// A Store provides access to key-value storage, where
+// values are stored based on a content-address provided
+// by the supplied hash function
+export class Store {
+  constructor (hash, storage) {
+    this.hash = hash
+    this.storage = storage
+  }
 
-export const jsonSerializer = hash => data => {
-  const json = JSON.stringify(data)
-  return { key: hash(json), content: json, deserialize: jsonDeserializer }
+  valueForKey (key, defaultValue) {
+    return new StoreValue(this.hash, this.storage, key)
+      .map(a => a != null ? a : defaultValue)
+  }
 }
 
 // An immutable content-addressed store
 // A Store contains an immutable value that is considered to be unique
 // based on the provided serializer's key generation algorithm
-export class Store {
-  constructor (serialize, deserialize, storage, key) {
-    this.serialize = serialize
-    this.deserialize = deserialize
+export class StoreValue {
+  constructor (hash, storage, key) {
+    this.hash = hash
     this.storage = storage
     this.key = key
   }
@@ -34,16 +43,38 @@ export class Store {
 
   // Comonad - extract value from this Store
   extract () {
-    return this.deserialize(this.storage[this.key])
+    return this.storage.get(this.key)
   }
 }
 
-// Return a store containing `data` as its value
-const update = (data, store) => {
-  const { key, content, deserialize } = store.serialize(data)
-  if (key === store.key) {
-    return store // the content already exists, bail out
+// Return a store containing `value` as its value
+const update = (value, store) => {
+  const key = store.hash(value)
+  // If the key is already present, don't bother setting the
+  // key/value pair again
+  const newStorage = store.storage.has(key)
+    ? store.storage : store.storage.set(key, value)
+
+  return new StoreValue(store.hash, newStorage, key)
+}
+
+// LocalStorage Adapter
+export class LocalStorage {
+  constructor (localStorage) {
+    this.localStorage = localStorage
   }
-  store.storage[key] = content
-  return new Store(store.serialize, deserialize, store.storage, key)
+
+  has (key) {
+    return this.localStorage.hasOwnProperty(key)
+  }
+
+  get (key) {
+    const value = this.localStorage.getItem(key)
+    return value == null ? value : JSON.parse(value)
+  }
+
+  set (key, value) {
+    this.localStorage.setItem(key, JSON.stringify(value))
+    return new LocalStorage(this.localStorage)
+  }
 }

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -1,27 +1,17 @@
 import { describe, it } from 'mocha'
 import assert from 'assert'
-import { jsonDeserializer, jsonSerializer } from '../src/index'
+import { LocalStorage } from '../src/index'
 
-describe('jsonSerializer', () => {
-  it('should return hash key and serialized content', () => {
-    const hash = s => `test${s}`
-    const data = { test: Math.random() }
-    const serialize = jsonSerializer(hash)
+describe('LocalStorage', () => {
+  describe('has', () => {
+    it('should return true when key present', () => {
+      const s = new LocalStorage({})
+      assert(!s.has('test'))
+    })
 
-    const { key, content, deserialize } = serialize(data)
-    assert.strictEqual(key, hash(JSON.stringify(data)))
-    assert.deepStrictEqual(data, deserialize(content))
-  })
-})
-
-describe('jsonDeserializer', () => {
-  it('should return undefined for null or undefined input', () => {
-    assert.strictEqual(undefined, jsonDeserializer(null))
-    assert.strictEqual(undefined, jsonDeserializer(undefined))
-  })
-
-  it('should return deserialized data for value input', () => {
-    const data = { test: Math.random() }
-    assert.deepStrictEqual(data, jsonDeserializer(JSON.stringify(data)))
+    it('should return false when key not present', () => {
+      const s = new LocalStorage({ test: '' })
+      assert(s.has('test'))
+    })
   })
 })


### PR DESCRIPTION
Refactor to separate Store and StoreValue, and introduce Storage interface.  Store represents a content-addressed key-value store.  StoreValue represents a single key-value pair.  Storage represents an underlying (possibly mutable) key-value storage.

The Storage interface is compatible with ES6 Map.  LocalStorage implements that interface for W3C Storage, i.e. window.localStorage.

BREAKING CHANGE: Creating a store now requires providing a Storage instance
### Todo
- [ ] Add tests
- [ ] Update README
